### PR TITLE
Fix YouTube URL.

### DIFF
--- a/data.json
+++ b/data.json
@@ -9,7 +9,7 @@
     },
     {
       "app": "YouTube",
-      "url": "https://www.youtube.com/user/{username}/videos",
+      "url": "https://www.youtube.com/c/{username}",
       "valid": "response.status == 200",
       "id": 2,
       "method": "GET"


### PR DESCRIPTION
The YouTube URL is not correct. It should be `https://www.youtube.com/c/USERNAME`, not `https://www.youtube.com/user/USERNAME/videos`. For example, if you try to view my channel at the https://www.youtube.com/user/relatedtitle/videos URL, you'll get a 404. But if you use the URL I propose (https://www.youtube.com/c/relatedtitle), it works just fine.