### PR TITLE
fix: change condition statement for os check

### DIFF
--- a/blackbird.py
+++ b/blackbird.py
@@ -129,7 +129,7 @@ if arguments.web:
         command.check_returncode()
 
 if arguments.username:
-    if 'win' in currentOs:
+    if 'win' in currentOs and currentOs != 'darwin':
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     asyncio.run(findUsername(arguments.username))
 elif arguments.list:


### PR DESCRIPTION
In Mac OS, `currentOs` is `darwin` which satisfies the `win` condition. This is causing error i.e.,

> error: AttributeError: module 'asyncio' has no attribute 'WindowsSelectorEventLoopPolicy'