### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.1
+aiohttp==3.8.3
 beautifulsoup4==4.11.1
 colorama==0.4.4
 Flask==2.1.1


### PR DESCRIPTION
Other things need to be updated as well but im too lazy to look em up. Causes a pip crash on windows 11 cuz it cant find find aiohttp 3.8.1. thats it.